### PR TITLE
Added ability to build over multiple architectures (arm64/amd64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:8
 
+ARG TARGETARCH
+
 LABEL Maintainer="Robert de Bock <robert@meinit.nl>"
 LABEL Description="Base CentOS OpenSSH server image"
 LABEL CentOS="8"
@@ -11,9 +13,14 @@ LABEL build_date="2023-06-13"
 
 ENV TINI_VERSION v0.19.0
 
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 
 EXPOSE 22
+
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 
 # This containers function is specifically to run/test ssh, ignore hints
 # about having openssh in a Dockerfile.

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-/bin/bash
+#!/bin/bash
 
 # Making all required files if they are not existing. (This means
 # you may add a Docker volume on /etc/ssh or /root to insert your


### PR DESCRIPTION
Hi thanks for the great work on making the OpenSSH image!
I encountered some issues when running the image on a ARM architectore OS, my environment was on docker desktop on a M1 Mac. 

So this PR is to make the Dockerfile support multi-arch building.

Here is an generated image with OpenSSH that works on both ARM64 and AMD64, if anyone just want to pull and use:

```
docker pull jijiechen/centos8-openssh:202312
```